### PR TITLE
Move lookahead hint to the correct place in the line

### DIFF
--- a/examples/gherkin/GherkinGrammar.berp
+++ b/examples/gherkin/GherkinGrammar.berp
@@ -18,7 +18,7 @@ Scenario! := #Scenario Scenario_Description Scenario_Step*
 ScenarioOutline! := #ScenarioOutline ScenarioOutline_Description ScenarioOutline_Step* Examples+
 // after the first "Examples" block, interpreting a tag line is ambiguous (tagline of next examples or of next scenario)
 // because of this, we need a lookahead hint, that connects the tag line to the next examples, if there is an examples block ahead
-Examples! := #TagLine[#Empty|#Comment|#TagLine->#Examples]* #Examples Examples_Description Examples_Table
+Examples! [#Empty|#Comment|#TagLine->#Examples]:= #TagLine* #Examples Examples_Description Examples_Table
 Examples_Table! := #TableRow+
 
 Scenario_Step := Step


### PR DESCRIPTION
This line in GherkinGrammar.berp fails to parse, and it looks like the lookahead hint accidentally got moved.

Fixes #15